### PR TITLE
Check for iPhone X in DefaultStatusBarHeight

### DIFF
--- a/Source/UIKitExtensions.swift
+++ b/Source/UIKitExtensions.swift
@@ -23,10 +23,17 @@
 
 import Foundation
 
-let DefaultStatusBarHeight : CGFloat = 20
+var DefaultStatusBarHeight: CGFloat {
+    if UIScreen.main.nativeBounds.height == 2436 {
+        // iPhone X
+        return 44
+    }
+    // All other iPhones/iPads
+    return 20
+}
 
 extension UIView {
-    class func panelAnimation(_ duration : TimeInterval, animations : @escaping (()->()), completion : (()->())? = nil) {
+    class func panelAnimation(_ duration: TimeInterval, animations: @escaping (()->()), completion: (()->())? = nil) {
         UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: animations) { _ in
             completion?()
         }


### PR DESCRIPTION
Compares the screen height to determine whether the devices is an iPhone X.
All other devices have a default height of 20.

I chose this approach as this [PR](https://github.com/teodorpatras/SideMenuController/pull/146) doesn't really remedy the issue. 

`UIApplication.shared.statusBarFrame.size.height` sometimes return 0 and theres a check for that prior to animating the status bar. Should it be 0, the default hardcoded value is used. 